### PR TITLE
時間に関する制約の追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,7 @@
 class EventsController < ApplicationController
   def index
     @current_events = Event.order(created_at: :desc).limit(5)
+    @popular_events = Event.find(Favorite.group(:event_id).order('count(event_id) desc').limit(5).pluck(:event_id))
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,6 +23,7 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     @participants = Participant.where(event_id: params[:id])
     @favorites = Favorite.where(event_id: params[:id])
+    @entry_status = @event.entry_status(@participants)
   end
 
   private

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,8 +5,7 @@ class FavoritesController < ApplicationController
   end
 
   def show
-    favorites = Favorite.where(user_id: current_user.id)
-    @events = favorites.map{|favorite| favorite.event}
+    @events =Event.includes(:participants).where(participants: {user_id: current_user.id}).order(created_at: :desc)
   end
 
   def destroy

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -10,6 +10,8 @@ class ParticipantsController < ApplicationController
   end
 
   def history
+    @events =Event.includes(:participants).where(participants: {user_id: current_user.id}).order(created_at: :desc)
+    @events.where!('event_start_at < ?', Time.current)
   end
 
   def destroy

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -5,14 +5,15 @@ class ParticipantsController < ApplicationController
   end
 
   def show
-    participants = Participant.where(user_id: current_user.id)
-    @events = participants.map{|participant| participant.event}
+    @events =Event.includes(:participants).where(participants: {user_id: current_user.id}).order(created_at: :desc)
+    @events.where!('event_start_at > ?', Time.current)
+  end
+
+  def history
   end
 
   def destroy
     Participant.find_by(user_id: current_user.id, event_id: params[:event_id]).destroy
     redirect_to event_path(params[:event_id])
   end
-
-  
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,9 +10,22 @@ class Event < ApplicationRecord
   validates :capacity,       presence: true
   validate :start_expire_check
 
+  # method
   def start_expire_check
     errors.add(:expire_at, "の日時は開催日時以前に設定してください。") unless
     self.event_start_at > self.expire_at
+  end
+
+  def entry_status(participants)
+    if Time.current > self.event_start_at 
+      return 0
+    elsif Time.current > self.expire_at
+      return 1
+    elsif self.capacity <= participants.count
+      return 2
+    else
+      return 3
+    end
   end
 
   # assosiation

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -30,8 +30,9 @@ class Event < ApplicationRecord
 
   # assosiation
   belongs_to :organizer, class_name: "User"
-  has_many :users, through: :participants
   has_many :participants
-  has_many :users, through: :favorites
+  has_many :users, through: :participants
   has_many :favorites
+  has_many :users, through: :favorites
+
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,10 +5,15 @@ class Event < ApplicationRecord
   validates :title,          presence: true, length: {maximum: 50}
   validates :place,          presence: true, length: {maximum: 50}
   validates :event_start_at, presence: true
-  validates :event_end_at,   presence: true
   validates :expire_at,      presence: true
   validates :discription,    presence: true, length: {maximum: 500}
   validates :capacity,       presence: true
+  validate :start_expire_check
+
+  def start_expire_check
+    errors.add(:expire_at, "の日時は開催日時以前に設定してください。") unless
+    self.event_start_at > self.expire_at
+  end
 
   # assosiation
   belongs_to :organizer, class_name: "User"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,9 @@ class User < ApplicationRecord
   has_one :profile, dependent: :destroy
   accepts_nested_attributes_for :profile
   has_many :organize_event, foreign_key: "organizer_id", class_name: "Event"
-  has_many :events, through: :participants
   has_many :participants
-  has_many :events, through: :favorites
+  has_many :events, through: :participants
   has_many :favorites
+  has_many :events, through: :favorites
+
 end

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -32,81 +32,31 @@
                   = current_event.favorites.count
     .main__event
       .main__event__title
-        人気イベント
+        お気に入りの多いイベント
       .main__event__contents
-        .main__event__contents__content
-          .main__event__contents__content__image
-            = image_tag '/images/rails-logo.png', size: "120x90"
-          .main__event__contents__content__detail
-            .main__event__contents__content__detail__title
-              = link_to "初めてのrails勉強会！！", "#"
-            .main__event__contents__content__detail__date
-              = icon('far', 'clock')
-              2020年2月22日
-            .main__event__contents__content__detail__place
-              = icon('fas', 'map-marker-alt')
-              東京都千代田区千代田１−１
-            .main__event__contents__content__detail__capacity
-              = icon('fas', 'user-friends')
-              18/20
-        .main__event__contents__content
-          .main__event__contents__content__image
-            = image_tag '/images/rails-logo.png', size: "120x90"
-          .main__event__contents__content__detail
-            .main__event__contents__content__detail__title
-              = link_to "初めてのrails勉強会！！", "#"
-            .main__event__contents__content__detail__date
-              = icon('far', 'clock')
-              2020年2月22日
-            .main__event__contents__content__detail__place
-              = icon('fas', 'map-marker-alt')
-              東京都千代田区千代田１−１
-            .main__event__contents__content__detail__capacity
-              = icon('fas', 'user-friends')
-              18/20
-        .main__event__contents__content
-          .main__event__contents__content__image
-            = image_tag '/images/rails-logo.png', size: "120x90"
-          .main__event__contents__content__detail
-            .main__event__contents__content__detail__title
-              = link_to "初めてのrails勉強会！！", "#"
-            .main__event__contents__content__detail__date
-              = icon('far', 'clock')
-              2020年2月22日
-            .main__event__contents__content__detail__place
-              = icon('fas', 'map-marker-alt')
-              東京都千代田区千代田１−１
-            .main__event__contents__content__detail__capacity
-              = icon('fas', 'user-friends')
-              18/20
-        .main__event__contents__content
-          .main__event__contents__content__image
-            = image_tag '/images/rails-logo.png', size: "120x90"
-          .main__event__contents__content__detail
-            .main__event__contents__content__detail__title
-              = link_to "初めてのrails勉強会！！", "#"
-            .main__event__contents__content__detail__date
-              = icon('far', 'clock')
-              2020年2月22日
-            .main__event__contents__content__detail__place
-              = icon('fas', 'map-marker-alt')
-              東京都千代田区千代田１−１
-            .main__event__contents__content__detail__capacity
-              = icon('fas', 'user-friends')
-              18/20
-        .main__event__contents__content
-          .main__event__contents__content__image
-            = image_tag '/images/rails-logo.png', size: "120x90"
-          .main__event__contents__content__detail
-            .main__event__contents__content__detail__title
-              = link_to "初めてのrails勉強会！！", "#"
-            .main__event__contents__content__detail__date
-              = icon('far', 'clock')
-              2020年2月22日
-            .main__event__contents__content__detail__place
-              = icon('fas', 'map-marker-alt')
-              東京都千代田区千代田１−１
-            .main__event__contents__content__detail__capacity
-              = icon('fas', 'user-friends')
-              18/20
+        - @popular_events.each do |current_event|
+          .main__event__contents__content
+            .main__event__contents__content__image
+              - if current_event.img.present?
+                = image_tag current_event.img.url , size: "120x90"
+              - else
+                = image_tag '/images/rails-logo.png', size: "120x90"
+            .main__event__contents__content__detail
+              .main__event__contents__content__detail__title
+                = link_to "#{current_event.title}", event_path(current_event.id)
+              .main__event__contents__content__detail__date
+                = icon('far', 'clock')
+                = current_event.event_start_at.strftime("%Y-%m-%d %H:%M")
+              .main__event__contents__content__detail__place
+                = icon('fas', 'map-marker-alt')
+                = current_event.place
+              .main__event__contents__content__detail__counter
+                .main__event__contents__content__detail__counter__capacity
+                  = icon('fas', 'user-friends')
+                  = current_event.participants.count
+                  \/
+                  = current_event.capacity
+                .main__event__contents__content__detail__counter__capacity
+                  = icon('fas', 'star')
+                  = current_event.favorites.count
 

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -37,13 +37,6 @@
             = f.datetime_select :event_start_at, {prompt:"--", use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year+1, date_separator:' / '}, {class: "event-content-form event-content-form--date"}
         .event-form__contents__content
           .event-form__contents__content__title
-            終了日時
-            .required
-              必須
-          .event-form__contents__content__form
-            = f.datetime_select :event_end_at, {prompt:"--", use_month_numbers:true, start_year:Time.now.year, end_year:Time.now.year+1, date_separator:' / '}, {class: "event-content-form event-content-form--date"}
-        .event-form__contents__content
-          .event-form__contents__content__title
             参加締め切り
             .required
               必須

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -28,8 +28,19 @@
     .event-show__join
       - if user_signed_in?
         - if !Participant.exists?(user_id:current_user.id,event_id:@event.id)
-          .event-show__join__btn
-            = link_to "参加する", participants_path(event_id: @event.id), method: :post
+          - case @entry_status
+          - when 0 then
+            .event-show__join__btn.event-show__join__btn--off
+              イベント終了済み
+          - when 1 then
+            .event-show__join__btn.event-show__join__btn--off
+              参加締め切り
+          - when 2 then
+            .event-show__join__btn.event-show__join__btn--off
+              定員オーバー
+          - when 3 then
+            .event-show__join__btn
+              = link_to "参加する", participants_path(event_id: @event.id), method: :post
         - else
           .event-show__join__btn.event-show__join__btn--off
             = link_to "参加取り消し", participants_path(event_id: @event.id), method: :delete

--- a/app/views/participants/history.html.haml
+++ b/app/views/participants/history.html.haml
@@ -1,0 +1,34 @@
+= render 'shared/header'
+.container
+  .u-main
+    = render 'shared/side-menu'
+    .u-main__contents
+      .main___event
+        .main__event__title
+          過去に参加したイベント
+        .main__event__contents
+          - @events.each do |event|
+            .main__event__contents__content
+              .main__event__contents__content__image
+                - if event.img.present?
+                  = image_tag event.img.url , size: "120x90"
+                - else
+                  = image_tag '/images/rails-logo.png', size: "120x90"
+              .main__event__contents__content__detail
+                .main__event__contents__content__detail__title
+                  = link_to "#{event.title}", event_path(event.id)
+                .main__event__contents__content__detail__date
+                  = icon('far', 'clock')
+                  = event.event_start_at.strftime("%Y-%m-%d %H:%M")
+                .main__event__contents__content__detail__place
+                  = icon('fas', 'map-marker-alt')
+                  = event.place
+                .main__event__contents__content__detail__counter
+                  .main__event__contents__content__detail__counter__capacity
+                    = icon('fas', 'user-friends')
+                    = event.participants.count
+                    \/
+                    = event.capacity
+                  .main__event__contents__content__detail__counter__capacity
+                    = icon('fas', 'star')
+                    = event.favorites.count

--- a/app/views/shared/_side-menu.html.haml
+++ b/app/views/shared/_side-menu.html.haml
@@ -5,6 +5,9 @@
     %li.side-menu__content
       = link_to "参加予定", participant_path(current_user.id), class: "side-menu__content__btn", method: :get
     %li.side-menu__content
+      = link_to "参加履歴", history_participant_path(current_user.id), class: "side-menu__content__btn", method: :get
+    %li.side-menu__content
       = link_to "お気に入り", favorite_path(current_user.id), class: "side-menu__content__btn", method: :get
     %li.side-menu__content
       = link_to "ログアウト", signout_users_path, class: "side-menu__content__btn", method: :get
+      

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,11 @@ Rails.application.routes.draw do
       get 'signout'
     end
   end
-  resources :participants, only: [:create, :show]
+  resources :participants, only: [:create, :show] do
+    member do
+      get 'history'
+    end
+  end
   resource :participants, only: [:destroy]
   resources :favorites, only: [:create, :show]
   resource :favorites, only: [:destroy]

--- a/db/migrate/20200301230420_remove_eventendat_from_events.rb
+++ b/db/migrate/20200301230420_remove_eventendat_from_events.rb
@@ -1,0 +1,5 @@
+class RemoveEventendatFromEvents < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :events, :event_end_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_01_200227) do
+ActiveRecord::Schema.define(version: 2020_03_01_230420) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.text "place", null: false
     t.datetime "event_start_at", null: false
-    t.datetime "event_end_at", null: false
     t.datetime "expire_at", null: false
     t.text "discription", null: false
     t.integer "capacity", null: false


### PR DESCRIPTION
# What
- イベント登録時に参加締め切りを開催時間以前に設定する制約の追加
- 終了したイベントは参加不可に
- 参加予定イベントで終了したイベントを非表示に
- 過去に参加したイベントをマイページから確認できるように

# Why
現在時間とイベントに設定した時間からできる操作を限定できるようにするため
イベントの管理をしやすくするため